### PR TITLE
Corrigido texto mostrado quando não há avaliações

### DIFF
--- a/assets/OpinionManagement/js/opinionManagement.js
+++ b/assets/OpinionManagement/js/opinionManagement.js
@@ -41,7 +41,8 @@ const showOpinions = registrationId => {
         }
     })
         .then(response => {
-            console.log(response)
+            if(response.redirected) throw new Error('Guest')
+            if (!response.ok) throw new Error(response.statusText)
             return response.json()
         })
         .then(opinions => {
@@ -62,11 +63,17 @@ const showOpinions = registrationId => {
             })
         })
         .catch(error => {
+
+            let { message } = error
+            if(error.message === 'Forbidden') message = 'Você não tem permissão para acessar este recurso.'
+            if(error.message === 'Guest') message = 'É necessário estar autenticado.'
+
             Swal.fire({
-                icon: "error",
                 title: "Oops...",
-                text: "Alconteceu um problema!",
-                footer: `<code style="font-size:8px">${error}</code>`
+                text: "Aconteceu um problema!",
+                footer: `<code style="font-size:11px; color:#c93">${message}</code>`,
+                showConfirmButton: false,
+                showCloseButton: true,
             })
         })
 }

--- a/assets/OpinionManagement/js/opinionManagement.js
+++ b/assets/OpinionManagement/js/opinionManagement.js
@@ -46,12 +46,11 @@ const showOpinions = registrationId => {
             return response.json()
         })
         .then(opinions => {
-            // @todo: Talvez seja algo a ser melhorado
+            // @todo: Em versões futuras fazer alteração para mostrar quem são os pareceristas com pendências na avaliação
             if(opinions.length === 0)
                 return Swal.fire({
-                    icon: "info",
-                    title: "Não há pareceristas",
-                    text: "Não há pareceristas para esta inscrição"
+                    title: "Não há avaliações!",
+                    text: "As avaliações desta inscrição ainda não foram iniciadas."
                 })
 
             const html = `<div>${opinions.map(opinion => opinionHtml(opinion)).join('')}</div>`;


### PR DESCRIPTION
O texto mostrado agora está mais coerente com o contexto de não haver avaliações.

![image](https://github.com/secultce/plugin-OpinionManagement/assets/42920699/2ac00ea2-41aa-487a-8cf8-c029ae59c225)
