### PR TITLE
Adicionada configuração para publicar manualmente os pareceres.

### DIFF
--- a/Controllers/OpinionManagement.php
+++ b/Controllers/OpinionManagement.php
@@ -65,9 +65,6 @@ class OpinionManagement extends Controller
             return;
         }
 
-        $this->json([
-            'success' => true,
-            'pqp' => (bool) null,
-        ]);
+        $this->json(['success' => true]);
     }
 }

--- a/Controllers/OpinionManagement.php
+++ b/Controllers/OpinionManagement.php
@@ -53,8 +53,21 @@ class OpinionManagement extends Controller
 
         $opportunity = $app->repo('Opportunity')->find($this->postData['id']);
         if(!$opportunity->isUserAdmin($app->user)) {
+            $this->errorJson(['permission-denied'], 403);
             return;
         }
 
+
+        $opportunity->setMetadata('publishedOpinions', 'true');
+        $error = $opportunity->save(true);
+        if($error) {
+            $this->errorJson(['error' => new \PDOException('Cannot save this data')], 500);
+            return;
+        }
+
+        $this->json([
+            'success' => true,
+            'pqp' => (bool) null,
+        ]);
     }
 }

--- a/Controllers/OpinionManagement.php
+++ b/Controllers/OpinionManagement.php
@@ -35,7 +35,6 @@ class OpinionManagement extends Controller
          * @var $registration \MapasCulturais\Entities\Registration
          */
         $registration = $app->repo('Registration')->find($this->getData['id']);
-        $opinions = [];
         if($registration->canUser('view')) {
             $opinions = new EvaluationList($registration);
             $this->json($opinions);
@@ -57,6 +56,5 @@ class OpinionManagement extends Controller
             return;
         }
 
-//        dump($opportunity->);
     }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -11,12 +11,11 @@ use MapasCulturais\App,
  */
 class Plugin extends \MapasCulturais\Plugin
 {
-
     public function _init(): void
     {
         $app = (new App)->i();
-
-        $app->hook('template(<<registration|opportunity>>.<<single|view>>.head):begin', function () use ($app) {
+        // Load assets in head
+        $app->hook('template(<<registration|opportunity|panel>>.<<single|view|registrations|index>>.head):begin', function () use ($app) {
             $app->view->enqueueScript(
                 'app',
                 'swal2',
@@ -32,39 +31,29 @@ class Plugin extends \MapasCulturais\Plugin
                 'opinionManagement',
                 'OpinionManagement/css/opinionManagement.css'
             );
-
             $app->view->enqueueScript(
                 'app',
                 'opinion-management',
                 'OpinionManagement/js/opinionManagement.js'
             );
         });
-        $app->hook('template(panel.<<registrations|index>>.head):begin', function () use ($app) {
-            $app->view->enqueueScript(
-                'app',
-                'swal2',
-                'js/sweetalert2.all.min.js'
-            );
-            $app->view->enqueueStyle(
-                'app',
-                'swal2-theme-secultce',
-                'css/swal2-secultce.min.css'
-            );
-            $app->view->enqueueStyle(
-                'app',
-                'opinionManagement',
-                'OpinionManagement/css/opinionManagement.css'
-            );
 
-            $app->view->enqueueScript(
-                'app',
-                'opinion-management',
-                'OpinionManagement/js/opinionManagement.js'
-            );
+        $app->hook('template(opportunity.edit.registration-config):after', function () use ($app) {
+            $opportunity = $this->controller->requestedEntity;
+            /**
+             * @todo: Refatorar quando for mudar para publicar pareceres técnicos
+             */
+            if($opportunity->evaluationMethodConfiguration->type != 'documentary') {
+                return;
+            }
+            $this->part('OpinionManagement/selection-autopublish', ['opportunity' => $opportunity]);
         });
 
         $app->hook('template(opportunity.single.registration-list-header):end', function() use($app) {
             $opportunity = $this->controller->requestedEntity;
+            /**
+             * @todo: Refatorar quando for mudar para publicar pareceres técnicos
+             */
             if($opportunity->evaluationMethodConfiguration->type != 'documentary') {
                 return;
             }
@@ -82,7 +71,11 @@ class Plugin extends \MapasCulturais\Plugin
                 });
             }
         });
+
         $app->hook('template(opportunity.single.user-registration-table--registration--status):end', function ($registration, $opportunity) use ($app) {
+            /**
+             * @todo: Refatorar quando for mudar para publicar pareceres técnicos
+             */
             if($opportunity->evaluationMethodConfiguration->type != 'documentary' || !$opportunity->publishedRegistrations) {
                 return;
             }
@@ -96,8 +89,9 @@ class Plugin extends \MapasCulturais\Plugin
             $registration = $this->controller->requestedEntity;
             $opportunity = $registration->opportunity;
 
-            // http://localhost:8080/inscricao/612180872/
-
+            /**
+             * @todo: Refatorar quando for mudar para publicar pareceres técnicos
+             */
             if($opportunity->evaluationMethodConfiguration->type != 'documentary' || (!$opportunity->publishedRegistrations && !$opportunity->canUser('@control'))) {
                 return;
             }
@@ -107,8 +101,10 @@ class Plugin extends \MapasCulturais\Plugin
             }
         });
 
-
         $app->hook('template(panel.<<registrations|index>>.panel-registration):end', function ($registration) use ($app) {
+            /**
+             * @todo: Refatorar quando for mudar para publicar pareceres técnicos
+             */
             if(!$registration->opportunity->publishedRegistrations
                 || $registration->opportunity->evaluationMethodConfiguration->type != 'documentary'
             ) return;
@@ -118,6 +114,11 @@ class Plugin extends \MapasCulturais\Plugin
                 'opinion-management',
                 'OpinionManagement/js/opinionManagement.js'
             );
+        });
+
+        $app->hook('entity(Opportunity).publishRegistrations:before', function () {
+            if($this->autopublishOpinions == 'Sim')
+                $this->setMetadata('publishedOpinions', 'true');
         });
     }
 
@@ -130,5 +131,20 @@ class Plugin extends \MapasCulturais\Plugin
 
         $app->registerController('opinionManagement', OpinionManagement::class);
 
+        $this->registerOpportunityMetadata('autopublishOpinions', [
+            'type' => 'select',
+            'default_value' => 'Não',
+            'label' => \MapasCulturais\i::__('Publicar pareceres automaticamente'),
+            'description' => \MapasCulturais\i::__('Indica se os pareceres devem ser publicados automaticamente'),
+            'options' => ['Sim', 'Não'],
+            'required' => true,
+        ]);
+        $this->registerOpportunityMetadata('publishedOpinions', [
+            'type' => 'select',
+            'label' => \MapasCulturais\i::__('Pareceres publicados'),
+            'default_value' => 'false',
+            'options' => ['true', 'false'],
+            'required' => true,
+        ]);
     }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -85,6 +85,21 @@ class Plugin extends \MapasCulturais\Plugin
             }
         });
 
+        $app->hook('template(opportunity.single.header-inscritos):actions', function () use ($app) {
+            $opportunity = $this->controller->requestedEntity;
+            /**
+             * @todo: Refatorar quando for mudar para publicar pareceres técnicos
+             */
+            if($opportunity->evaluationMethodConfiguration->type != 'documentary'
+                || $opportunity->autopublishOpinions == 'Não'
+                || $opportunity->publishedOpinions == 'true'
+            ) {
+                return;
+            }
+
+            $app->part('OpinionManagement/admin-btn-publish-opinions.php', ['opportunity' => $opportunity]);
+        });
+
         $app->hook('template(registration.view.header-fieldset):after', function() use($app) {
             $registration = $this->controller->requestedEntity;
             $opportunity = $registration->opportunity;

--- a/Plugin.php
+++ b/Plugin.php
@@ -76,7 +76,7 @@ class Plugin extends \MapasCulturais\Plugin
             /**
              * @todo: Refatorar quando for mudar para publicar pareceres técnicos
              */
-            if($opportunity->evaluationMethodConfiguration->type != 'documentary' || !$opportunity->publishedRegistrations) {
+            if($opportunity->publishedOpinions != 'true') {
                 return;
             }
 
@@ -85,19 +85,19 @@ class Plugin extends \MapasCulturais\Plugin
             }
         });
 
-        $app->hook('template(opportunity.single.header-inscritos):actions', function () use ($app) {
+        $app->hook('template(opportunity.single.opportunity-registrations--tables):begin', function () use ($app) {
             $opportunity = $this->controller->requestedEntity;
             /**
              * @todo: Refatorar quando for mudar para publicar pareceres técnicos
              */
             if($opportunity->evaluationMethodConfiguration->type != 'documentary'
-                || $opportunity->autopublishOpinions == 'Não'
+                || $opportunity->autopublishOpinions !== 'Não'
                 || $opportunity->publishedOpinions == 'true'
             ) {
                 return;
             }
 
-            $app->part('OpinionManagement/admin-btn-publish-opinions.php', ['opportunity' => $opportunity]);
+            $this->part('OpinionManagement/admin-btn-publish-opinions.php', ['opportunity' => $opportunity]);
         });
 
         $app->hook('template(registration.view.header-fieldset):after', function() use($app) {

--- a/assets/OpinionManagement/css/opinionManagement.css
+++ b/assets/OpinionManagement/css/opinionManagement.css
@@ -145,3 +145,13 @@ div:has(>.showOpinion) {
     text-align: start;
     margin-top: 8px;
 }
+
+.opinions-section {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+
+.opinions-section hr {
+    width: 100%;
+}

--- a/assets/OpinionManagement/js/opinionManagement.js
+++ b/assets/OpinionManagement/js/opinionManagement.js
@@ -6,7 +6,6 @@ const handleChkCollapseChange = target => {
     }
 }
 
-
 const opinionHtml = opinion => {
     let htmlParsed = '<div class="opinion">'
     htmlParsed += `<div class="evaluation-title">
@@ -67,12 +66,63 @@ const showOpinions = registrationId => {
             if(error.message === 'Forbidden') message = 'Você não tem permissão para acessar este recurso.'
             if(error.message === 'Guest') message = 'É necessário estar autenticado.'
 
-            Swal.fire({
-                title: "Oops...",
-                text: "Aconteceu um problema!",
-                footer: `<code style="font-size:11px; color:#c93">${message}</code>`,
-                showConfirmButton: false,
-                showCloseButton: true,
-            })
+            errorAlert(message)
         })
+}
+
+const publishOpinions = target => {
+    const opportunityId = target.getAttribute('data-id');
+
+    Swal.fire({
+        title: "Essa ação é irreversível!",
+        html: "Ao clicar em <strong>'Publicar'</strong> você está publicando os pareceres para a visualização dos proponentes. Isso não pode ser desfeito.",
+        showConfirmButton: true,
+        showCloseButton: false,
+        showCancelButton: true,
+        confirmButtonText: 'Publicar',
+        cancelButtonText: 'Cancelar',
+    })
+        .then(result => {
+            if(result.isConfirmed)
+                fetch(MapasCulturais.baseURL + 'opinionManagement/publishOpinions', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: new URLSearchParams({
+                        id: opportunityId,
+                    }),
+                })
+                    .then(response => {
+                        if(response.redirected) throw new Error('Guest')
+                        if (!response.ok) throw new Error(response.statusText)
+                        return response.json()
+                    })
+                    .then(response => {
+                        console.log(response)
+                        Swal.fire({
+                            title: "Pareceres publicados com sucesso!",
+                            text: "Os pareceres desta inscrição agora encontram-se publicados.",
+                            showConfirmButton: false,
+                            showCloseButton: true,
+                        })
+                    })
+                    .catch(error => {
+                        let { message } = error
+                        if(error.message === 'Forbidden') message = 'Você não tem permissão para acessar este recurso.'
+                        if(error.message === 'Guest') message = 'É necessário estar autenticado.'
+
+                        errorAlert(message)
+                    })
+        })
+}
+
+const errorAlert = message => {
+    Swal.fire({
+        title: "Oops...",
+        text: "Aconteceu um problema!",
+        footer: `<code style="font-size:11px; color:#c93">${message}</code>`,
+        showConfirmButton: false,
+        showCloseButton: true,
+    })
 }

--- a/layouts/parts/OpinionManagement/admin-btn-publish-opinions.php
+++ b/layouts/parts/OpinionManagement/admin-btn-publish-opinions.php
@@ -1,8 +1,18 @@
 <?php
 /** @var \MapasCulturais\Entities\Opportunity $opportunity */
 ?>
-<button
-    class="btn-primary"
-    data-id="<?= $opportunity->id ?>"
-    ng-if="<?= $opportunity->publishedOpinions ?>"
-><?= \MapasCulturais\i::__('Publicar Pareceres') ?></button>
+<?php $this->applyTemplateHook('opinions-section','before'); ?>
+<section class="opinions-section">
+    <h3>Pareceres</h3>
+    <div>
+        <?php $this->applyTemplateHook('opinions-section.buttons','begin'); ?>
+        <button
+            class="btn btn-primary"
+            onclick="publishOpinions(this)"
+            data-id="<?= $opportunity->id ?>"
+        ><?= \MapasCulturais\i::__('Publicar Pareceres') ?></button>
+        <?php $this->applyTemplateHook('opinions-section.buttons','end'); ?>
+    </div>
+    <hr>
+</section>
+<?php $this->applyTemplateHook('opinions-section','after'); ?>

--- a/layouts/parts/OpinionManagement/admin-btn-publish-opinions.php
+++ b/layouts/parts/OpinionManagement/admin-btn-publish-opinions.php
@@ -1,0 +1,8 @@
+<?php
+/** @var \MapasCulturais\Entities\Opportunity $opportunity */
+?>
+<button
+    class="btn-primary"
+    data-id="<?= $opportunity->id ?>"
+    ng-if="<?= $opportunity->publishedOpinions ?>"
+><?= \MapasCulturais\i::__('Publicar Pareceres') ?></button>

--- a/layouts/parts/OpinionManagement/selection-autopublish.php
+++ b/layouts/parts/OpinionManagement/selection-autopublish.php
@@ -1,0 +1,13 @@
+<div class="registration-fieldset">
+    <h4>Publicação de Pareceres</h4>
+    <p>Deseja que os pareceres desta fase/oportunidade sejam publicados para os proponentes automaticamente ao publicar os resultados?</p>
+    <span class="js-editable"
+          data-edit="autopublishOpinions"
+          data-original-title="Publicar pareceres automaticamente"
+    >
+        <?= /** @var \MapasCulturais\Entities\Opportunity $opportunity */
+        $opportunity->getMetadata('autopublishOpinions') ?>
+    </span>
+    <br><br>
+    <em>Caso marque "Não" aparecerá um botão para publicar pareceres manualmente na aba de inscrições.</em>
+</div>

--- a/layouts/parts/OpinionManagement/selection-autopublish.php
+++ b/layouts/parts/OpinionManagement/selection-autopublish.php
@@ -1,12 +1,20 @@
-<div class="registration-fieldset">
+<style>
+    #opinions-config:has(~ #evaluations-config[style="display: none;"]) {
+        display: none;
+    }
+</style>
+
+<div id="opinions-config" class="registration-fieldset">
     <h4>Publicação de Pareceres</h4>
     <p>Deseja que os pareceres desta fase/oportunidade sejam publicados para os proponentes automaticamente ao publicar os resultados?</p>
-    <span class="js-editable"
-          data-edit="autopublishOpinions"
-          data-original-title="Publicar pareceres automaticamente"
+    <span
+        class="js-editable editable editable-click editable-unsaved"
+        data-edit="autopublishOpinions"
+        data-original-title="Publicar pareceres automaticamente"
+        data-value="<?= /** @var \MapasCulturais\Entities\Opportunity $opportunity */
+        $opportunity->getMetadata('autopublishOpinions') ?>"
     >
-        <?= /** @var \MapasCulturais\Entities\Opportunity $opportunity */
-        $opportunity->getMetadata('autopublishOpinions') ?>
+        <?= $opportunity->getMetadata('autopublishOpinions') ?>
     </span>
     <br><br>
     <em>Caso marque "Não" aparecerá um botão para publicar pareceres manualmente na aba de inscrições.</em>


### PR DESCRIPTION
# Publicar parecer manualmente
PR vinculado a issue #5.

## Campo de configuração de publicação automática
Ao criar a oportunidade, agora existe um novo campo na aba de configurações da avaliação em que deve-se indicar se a publicação dos pareceres vai acontecer automaticamente (ao publicar resultado) ou somente de forma manual.

![image](https://github.com/secultce/plugin-OpinionManagement/assets/42920699/7e3c2bae-aebd-4af0-ba49-c1d52dbcce03)

## Botão de publicação manual
Ao deixar marcado "Não" um botão será adicionado para o administrador da oportunidade na aba de inscritos:
![image](https://github.com/secultce/plugin-OpinionManagement/assets/42920699/368405e2-1a04-4ffa-9867-6a8e53986d05)
