### PR TITLE
Correção do botão "Visualizar Pareceres" não aparecendo para os proponentes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.
 ### Adicionado
 - Adicionada notificação no painel de controle do proponente quando o parecer é publicado.
 ### Correções
-- Retirado link fantasma para o perfil do parecerista na visão do proponente.
+- Retirado link fantasma para o perfil do parecerista na visão do proponente;
+- Corrigido bug em que botão "Visualizar Pareceres" não aparecia para o proponente, mesmo com os pareceres publicados.
 
 ## [1.1.0] - 2024-03-13
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Todas as mudanças relevantes serão documentadas nesse arquivo.
 
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0), e esse projeto adere ao [Semantic Versionning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Adicionado
+- Adicionada notificação no painel de controle do proponente quando o parecer é publicado.
+### Correções
+- Retirado link fantasma para o perfil do parecerista na visão do proponente.
+
 ## [1.1.0] - 2024-03-13
 ### Adicionado
 - Agora o administrador pode selecionar se quer fazer publicação dos pareceres de forma automática ou manual;
@@ -10,5 +16,5 @@ O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.
 
 ## [1.0.0] - 2024-02-27
 ### Adicionado
-- O administrador da oportunidade consegue ver a lista de pareceres na aba de inscrições da oportunidade.
+- O administrador da oportunidade consegue ver a lista de pareceres na aba de inscrições da oportunidade;
 - O proponente consegue visualizar o parecer documental desde que a oportunidade esteja com o resultado publicado.

--- a/Controllers/OpinionManagement.php
+++ b/Controllers/OpinionManagement.php
@@ -92,17 +92,14 @@ class OpinionManagement extends Controller
             $notification = new Notification();
             $notification->user = $registration->owner->user;
             $notification->message =
-                "Sua inscrição " .
-                "<a style='font-weight:bold;' href='/inscricao/{$registration->id}'>" .
-                    $registration->number .
-                "</a>" .
-                " da oportunidade " .
-                "<a style='font-weight:bold;' href='/oportunidade/{$opportunity->id}'/>" .
-                    $opportunity->name .
-                "</a>" .
-                "está com os pareceres publicados.";
+                sprintf(
+                    "Sua inscrição <a style='font-weight:bold;' href='/inscricao/{$registration->id}'>%s</a>" .
+                    " da oportunidade <a style='font-weight:bold;' href='/oportunidade/{$opportunity->id}'/>%s</a>está com os pareceres publicados.",
+                    $registration->number,
+                    $opportunity->name
+                );
             $notification->save(true);
-            $app->log->debug("Notificação {$i}/{$count} enviada para o usuário {$registration->owner->user->id} ({$registration->owner->name})");
+            $app->log->debug("Notificação ".($i+1)."/$count enviada para o usuário {$registration->owner->user->id} ({$registration->owner->name})");
         }
 
         return true;

--- a/Plugin.php
+++ b/Plugin.php
@@ -133,12 +133,13 @@ class Plugin extends \MapasCulturais\Plugin
         });
 
         $app->hook('entity(Opportunity).publishRegistrations:before', function () {
-            if($this->autopublishOpinions == 'Sim') {
-                $this->setMetadata('publishedOpinions', 'true');
+            if($this->autopublishOpinions !== 'Sim') {
+                return;
             }
+            $this->setMetadata('publishedOpinions', 'true');
+            (new OpinionManagement())->notificateUsers($this->id);
         });
 
-        // @todo: Colocar a notificação quando publicar automaticamente os pareceres
     }
 
     /**

--- a/Plugin.php
+++ b/Plugin.php
@@ -4,6 +4,7 @@ namespace OpinionManagement;
 
 use MapasCulturais\App,
     OpinionManagement\Controllers\OpinionManagement;
+use MapasCulturais\Entities\Notification;
 
 /**
  * @method part(string $string,  array $args = [])
@@ -132,9 +133,12 @@ class Plugin extends \MapasCulturais\Plugin
         });
 
         $app->hook('entity(Opportunity).publishRegistrations:before', function () {
-            if($this->autopublishOpinions == 'Sim')
+            if($this->autopublishOpinions == 'Sim') {
                 $this->setMetadata('publishedOpinions', 'true');
+            }
         });
+
+        // @todo: Colocar a notificação quando publicar automaticamente os pareceres
     }
 
     /**

--- a/Plugin.php
+++ b/Plugin.php
@@ -108,7 +108,11 @@ class Plugin extends \MapasCulturais\Plugin
             /**
              * @todo: Refatorar quando for mudar para publicar pareceres técnicos
              */
-            if($opportunity->evaluationMethodConfiguration->type != 'documentary' || (!$opportunity->publishedRegistrations && !$opportunity->canUser('@control'))) {
+            if($opportunity->evaluationMethodConfiguration->type != 'documentary'
+                || (!$opportunity->publishedOpinions
+                    && !$opportunity->canUser('@control')
+                )
+            ) {
                 return;
             }
 
@@ -121,7 +125,7 @@ class Plugin extends \MapasCulturais\Plugin
             /**
              * @todo: Refatorar quando for mudar para publicar pareceres técnicos
              */
-            if(!$registration->opportunity->publishedRegistrations
+            if(!$registration->opportunity->publishedOpinions
                 || $registration->opportunity->evaluationMethodConfiguration->type != 'documentary'
             ) return;
             $this->part('OpinionManagement/user-btn-show-opinion.php', ['registration' => $registration]);

--- a/assets/OpinionManagement/js/opinionManagement.js
+++ b/assets/OpinionManagement/js/opinionManagement.js
@@ -9,7 +9,13 @@ const handleChkCollapseChange = target => {
 const opinionHtml = opinion => {
     let htmlParsed = '<div class="opinion">'
     htmlParsed += `<div class="evaluation-title">
-        <h3>Parecerista <a href="${opinion.agent.singleUrl}" target="_blank">${opinion.agent.name}</a></h3>
+        <h3>
+            Parecerista
+            ${opinion.agent.singleUrl ?
+                '<a href="'+opinion.agent.singleUrl+'" target="_blank">'+opinion.agent.name+'</a>' :
+                opinion.agent.name
+            }
+        </h3>
         <label for="chk-collapse-${opinion.id}"><div class="collapsible"></div></label>
         <p>Resultado da avaliação documental:<a href="${opinion.singleUrl}" class="criteria-status-${opinion.result < 0 ? 'invalid' : 'valid'}"></a></p>
     </div>

--- a/assets/OpinionManagement/js/opinionManagement.js
+++ b/assets/OpinionManagement/js/opinionManagement.js
@@ -132,3 +132,37 @@ const errorAlert = message => {
         showCloseButton: true,
     })
 }
+
+alertPublish = id => {
+    Swal.fire({
+        title: "Tem certeza?",
+        html: "<strong>ATENÇÃO</strong>, essa ação é uma ação irreversível. Caso a próxima fase seja uma prestação de contas, primeiro crie a fase de prestação de contas para só depois fazer a publicação.",
+        showConfirmButton: true,
+        showCloseButton: false,
+        showCancelButton: true,
+        confirmButtonText: 'Publicar',
+        cancelButtonText: 'Cancelar',
+    })
+        .then(function (result) {
+            if(!result.isConfirmed) {
+                MapasCulturais.Messages.alert("Ação cancelada!")
+                return
+            }
+
+            let loading = Swal.fire({
+                title: "Verificando se há notificações a serem enviadas.",
+                allowOutsideClick: false,
+                showConfirmButton: false,
+                didOpen: () => {
+                    Swal.showLoading();
+                },
+            })
+
+            var url = MapasCulturais.createUrl('opportunity', 'publishRegistrations', [id]);
+            $.get(url, function() {
+                loading.close()
+                MapasCulturais.Messages.success('Resultado publicado');
+            })
+            location.reload();
+        });
+}


### PR DESCRIPTION
## O botão para visualizar os pareceres não estava aparecendo em alguns casos.
Foi corrigida a forma como é feita a verificação se esse botão deve aparecer ou não.

> [!Note]
Esse PR só pode ser mergeado após o PR #16.